### PR TITLE
Revert "Merge pull request #52 from gryphendowre/SP-5370"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <pdi.version>9.0.0.0-SNAPSHOT</pdi.version>
     <commons-xul.version>9.0.0.0-SNAPSHOT</commons-xul.version>
     <commons-io.version>1.4</commons-io.version>
+    <commons-vfs2>2.2</commons-vfs2>
     <junit.version>4.7</junit.version>
     <mockito.version>1.8.4</mockito.version>
   </properties>
@@ -41,6 +42,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
+      <version>${commons-vfs2}</version>
       <scope>compile</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
This reverts commit 57996e34ab0b21e85e597cd4abc59779ae48e23d, reversing
changes made to a351e01668489f2debfd0f3b48ef0f3590232825.

This Revert PR is part of a series:
- https://github.com/pentaho/maven-parent-poms/pull/229
- https://github.com/pentaho/apache-vfs-browser/pull/62
- https://github.com/pentaho/big-data-plugin/pull/2040
- https://github.com/webdetails/cpk/pull/87
- https://github.com/pentaho/data-access/pull/1091
- https://github.com/pentaho/mondrian/pull/1202
- https://github.com/pentaho/pdi-jms-plugin/pull/76
- https://github.com/pentaho/pdi-platform-utils-plugin/pull/104
- https://github.com/pentaho/pdi-plugins-ee/pull/174
- https://github.com/pentaho/pdi-sap-hana-bulk-loader-plugin/pull/84
- https://github.com/pentaho/pdi-teradata-tpt-plugin/pull/53
- https://github.com/pentaho/pentaho-big-data-ee/pull/444
- https://github.com/pentaho/pentaho-commons-database/pull/179
- https://github.com/pentaho/pentaho-data-mining/pull/26
- https://github.com/pentaho/pentaho-det-ee/pull/616
- https://github.com/pentaho/pentaho-hdfs-vfs/pull/23
- https://github.com/pentaho/pentaho-karaf-assembly/pull/635
- https://github.com/pentaho/pentaho-karaf-ee-assembly/pull/290
- https://github.com/pentaho/pentaho-kettle/pull/7334
- https://github.com/pentaho/pentaho-metaverse/pull/621
- https://github.com/pentaho/pentaho-osgi-bundles/pull/363
- https://github.com/pentaho/pentaho-platform-plugin-common-ui/pull/1504
- https://github.com/pentaho/pentaho-platform-plugin-geo/pull/341
- https://github.com/pentaho/pentaho-platform-plugin-interactive-reporting/pull/790
- https://github.com/pentaho/pentaho-platform/pull/4658
- https://github.com/pentaho/pentaho-reporting/pull/1342
- https://github.com/pentaho/pentaho-s3-vfs/pull/94
- https://github.com/pentaho/worker-nodes-ee-plugin/pull/17